### PR TITLE
Fix `cuda` support for `jax` installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ conda activate <env_name>
 ```
 To locally install this package, clone the repository and in the repo root, run
 ```
-pip install . --default-timeout=100 future
+pip install . --default-timeout=100 future --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html --find-links https://download.pytorch.org/whl/cu118
 ```
 
 ### Developers
@@ -25,7 +25,7 @@ conda activate <env_name>
 ```
 Install the project with the editable flag and development dependencies:
 ```
-pip install -e .[all] --default-timeout=100 future
+pip install -e .[all] --default-timeout=100 future --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html --find-links https://download.pytorch.org/whl/cu118
 ```
 Then, install pre-commit hooks by running the following in the repo root:
 ```

--- a/ambersim/__init__.py
+++ b/ambersim/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+# package root
+ROOT = str(Path(__file__).parent.parent)

--- a/models/pendulum/pendulum.urdf
+++ b/models/pendulum/pendulum.urdf
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+
+<robot name="pendulum">
+  <!-- dummy fixed base link rigidly attached to the world -->
+  <link name="base"/>
+  <joint name="fixed_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base"/>
+  </joint>
+
+  <!-- pendulum link -->
+  <link name="pendulum_link">
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 -0.5"/>
+      <geometry>
+        <cylinder length="1.0" radius="0.02"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -0.5"/>
+      <geometry>
+        <cylinder length="1.0" radius="0.02"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="1"/>
+      <origin rpy="0 0 0" xyz="0 0 -0.5"/>
+      <inertia ixx="0.083433" ixy="0" ixz="0" iyy="0.083433" iyz="0" izz="0.0002"/>
+    </inertial>
+  </link>
+
+  <!-- pendulum joint -->
+  <joint name="pendulum_joint" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base"/>
+    <child link="pendulum_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="2.0" velocity="8.0" lower="-3.1416" upper="3.1416"/>
+  </joint>
+</robot>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "jax>=0.4.1",
+    "jax[cuda11_local]>=0.4.1",
     "jaxlib>=0.4.1",
     "matplotlib>=3.5.2",
     "mujoco>=3.0.0",
@@ -45,13 +45,6 @@ test = [
 
 # All packages
 all = ["ambersim[dev, test]"]
-
-[options]
-# to download torch compatible with Cuda 11.8 and newest jax releases
-dependency_links = [
-    "https://download.pytorch.org/whl/cu118",
-    "https://storage.googleapis.com/jax-releases/jax_releases.html",
-]
 
 [tool.setuptools.packages.find]
 include = ["ambersim"]


### PR DESCRIPTION
Fixes a problem where `jax` and `jaxlib` were installed without correct `cuda` support using the installation instructions in the README.