### PR TITLE
Add boilerplate code for RL pipeline

### DIFF
--- a/ambersim/base.py
+++ b/ambersim/base.py
@@ -1,0 +1,100 @@
+import jax
+from jax import numpy as jp
+import numpy as np
+from typing import Tuple, Dict, Any
+
+from brax.base import Base, Motion, Transform
+from brax.envs.base import Env
+import mujoco
+from mujoco import mjx
+from flax import struct
+
+
+class MjxEnv(Env):
+    """API for driving an MJX system for training and inference in brax."""
+
+    def __init__(
+        self,
+        mj_model: mujoco.MjModel,
+        physics_steps_per_control_step: int = 1,
+    ):
+        """Initializes MjxEnv.
+
+        Args:
+          mj_model: mujoco.MjModel
+          physics_steps_per_control_step: the number of times to step the physics
+            pipeline for each environment step
+        """
+        self.model = mj_model
+        self.data = mujoco.MjData(mj_model)
+        self.sys = mjx.device_put(mj_model)
+        self._physics_steps_per_control_step = physics_steps_per_control_step
+
+    def pipeline_init(self, qpos: jax.Array, qvel: jax.Array) -> mjx.Data:
+        """Initializes the physics state."""
+        data = mjx.device_put(self.data)
+        data = data.replace(qpos=qpos, qvel=qvel, ctrl=jp.zeros(self.sys.nu))
+        data = mjx.forward(self.sys, data)
+        return data
+
+    def pipeline_step(self, data: mjx.Data, ctrl: jax.Array) -> mjx.Data:
+        """Takes a physics step using the physics pipeline."""
+
+        def f(data, _):
+            data = data.replace(ctrl=ctrl)
+            return (
+                mjx.step(self.sys, data),
+                None,
+            )
+
+        data, _ = jax.lax.scan(f, data, (), self._physics_steps_per_control_step)
+        return data
+
+    @property
+    def dt(self) -> jax.Array:
+        """The timestep used for each env step."""
+        return self.sys.opt.timestep * self._physics_steps_per_control_step
+
+    @property
+    def observation_size(self) -> int:
+        rng = jax.random.PRNGKey(0)
+        reset_state = self.unwrapped.reset(rng)
+        return reset_state.obs.shape[-1]
+
+    @property
+    def action_size(self) -> int:
+        return self.sys.nu
+
+    @property
+    def backend(self) -> str:
+        return "mjx"
+
+    def _pos_vel(self, data: mjx.Data) -> Tuple[Transform, Motion]:
+        """Returns 6d spatial transform and 6d velocity for all bodies."""
+        x = Transform(pos=data.xpos[1:, :], rot=data.xquat[1:, :])
+        cvel = Motion(vel=data.cvel[1:, 3:], ang=data.cvel[1:, :3])
+        offset = data.xpos[1:, :] - data.subtree_com[self.model.body_rootid[np.arange(1, self.model.nbody)]]
+        xd = Transform.create(pos=offset).vmap().do(cvel)
+        return x, xd
+
+
+@struct.dataclass
+class State(Base):
+    """Environment state for training and inference with brax.
+
+    Args:
+      pipeline_state: the physics state, mjx.Data
+      obs: environment observations
+      reward: environment reward
+      done: boolean, True if the current episode has terminated
+      metrics: metrics that get tracked per environment step
+      info: environment variables defined and updated by the environment reset
+        and step functions
+    """
+
+    pipeline_state: mjx.Data
+    obs: jax.Array
+    reward: jax.Array
+    done: jax.Array
+    metrics: Dict[str, jax.Array] = struct.field(default_factory=dict)
+    info: Dict[str, Any] = struct.field(default_factory=dict)

--- a/ambersim/rl/base.py
+++ b/ambersim/rl/base.py
@@ -1,13 +1,13 @@
-import jax
-from jax import numpy as jp
-import numpy as np
-from typing import Tuple, Dict, Any
+from typing import Any, Dict, Tuple
 
+import jax
+import mujoco
+import numpy as np
 from brax.base import Base, Motion, Transform
 from brax.envs.base import Env
-import mujoco
-from mujoco import mjx
 from flax import struct
+from jax import numpy as jp
+from mujoco import mjx
 
 
 class MjxEnv(Env):
@@ -17,14 +17,15 @@ class MjxEnv(Env):
         self,
         mj_model: mujoco.MjModel,
         physics_steps_per_control_step: int = 1,
-    ):
+    ) -> None:
         """Initializes MjxEnv.
 
         Args:
-          mj_model: mujoco.MjModel
+          mj_model: the MuJoCo model.
           physics_steps_per_control_step: the number of times to step the physics
-            pipeline for each environment step
+            pipeline for each environment step.
         """
+        assert physics_steps_per_control_step >= 1
         self.model = mj_model
         self.data = mujoco.MjData(mj_model)
         self.sys = mjx.device_put(mj_model)
@@ -42,10 +43,7 @@ class MjxEnv(Env):
 
         def f(data, _):
             data = data.replace(ctrl=ctrl)
-            return (
-                mjx.step(self.sys, data),
-                None,
-            )
+            return mjx.step(self.sys, data), None
 
         data, _ = jax.lax.scan(f, data, (), self._physics_steps_per_control_step)
         return data
@@ -57,16 +55,23 @@ class MjxEnv(Env):
 
     @property
     def observation_size(self) -> int:
+        """Dimension of the observation space."""
         rng = jax.random.PRNGKey(0)
         reset_state = self.unwrapped.reset(rng)
         return reset_state.obs.shape[-1]
 
     @property
     def action_size(self) -> int:
+        """Dimension of the action space."""
         return self.sys.nu
 
     @property
     def backend(self) -> str:
+        """The brax physics backend.
+
+        The options are ['generalized', 'spring', 'positional', 'mjx'].
+        See: github.com/google/brax/tree/16304037a36b1d9c8c0b3084f57d1159627b636b#one-api-three-pipelines
+        """
         return "mjx"
 
     def _pos_vel(self, data: mjx.Data) -> Tuple[Transform, Motion]:
@@ -83,13 +88,12 @@ class State(Base):
     """Environment state for training and inference with brax.
 
     Args:
-      pipeline_state: the physics state, mjx.Data
-      obs: environment observations
-      reward: environment reward
-      done: boolean, True if the current episode has terminated
-      metrics: metrics that get tracked per environment step
-      info: environment variables defined and updated by the environment reset
-        and step functions
+        pipeline_state: the physics state.
+        obs: environment observations.
+        reward: environment reward.
+        done: True if the current episode has terminated.
+        metrics: metrics that get tracked per environment step.
+        info: environment variables defined and updated by the environment reset and step functions.
     """
 
     pipeline_state: mjx.Data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 dependencies = [
     "brax>=0.9.3",
     "dm_control>=1.0.0",
+    "flax>=0.7.5",
     "jax[cuda11_local]>=0.4.1",
     "jaxlib>=0.4.1",
     "matplotlib>=3.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "brax>=0.9.3",
+    "coacd>=1.0.0",
     "dm_control>=1.0.0",
     "flax>=0.7.5",
     "jax[cuda11_local]>=0.4.1",
@@ -43,6 +44,7 @@ dev = [
 test = [
     "cvxpy>=1.4.1",
     "drake>=1.21.0",
+    "libigl>=2.4.0",
     "pin>=2.6.20",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "coacd>=1.0.0",
+    "brax>=0.9.3",
     "dm_control>=1.0.0",
     "jax[cuda11_local]>=0.4.1",
     "jaxlib>=0.4.1",
@@ -40,11 +40,9 @@ dev = [
 
 # Test-specific packages for verification
 test = [
-    "brax>=0.9.0",
     "cvxpy>=1.4.1",
     "drake>=1.21.0",
     "pin>=2.6.20",
-    "libigl>=2.4.0",
 ]
 
 # All packages


### PR DESCRIPTION
Does what it says on the tin. Major changes:
* Adds `base.py`, which implements both a base `MjxEnv` class for environment management w/ Brax, and a `State` class to represent the RL state. This is copy-pasted from the `mjx` [tutorial notebook](https://colab.research.google.com/github/google-deepmind/mujoco/blob/main/mjx/tutorial.ipynb). 
* Adds `flux` and `brax` as dependencies since they're intertwined with the current "idiomatic" way of doing RL in `mjx`, which uses the algorithms implemented in `brax`.
* Also closes #14.