### PR TITLE
Add Actuators when Parsing URDF

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -27,6 +27,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[all] --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html --find-links https://download.pytorch.org/whl/cu118
       - name: Run black
         run: black --check .

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ pre-commit install
 We have implemented some custom utils for model parsing, but they aren't complete/perfect. Here are some guidelines for when you want to use this codebase for a custom project:
 * it's OK to just use URDFs and use our utils for loading them into `mjx` if you don't care too much about collision filtering or mujoco-specific elements like lights, sites, etc.
 * if you decide to use URDFs instead of converting the model description into an `xml`, then you should add a `<mujoco>` tag with some specific settings to the top of your URDF. See the examples in this repo as guidance.
+	* you should also make sure that your actuated joints have `<transmission>` blocks associated with them, as this is what our parser looks for to add actuators to the mujoco model.
 * if you decide to convert the URDF to an XML, then we have some custom utils for helping with the initial conversion, but if you want to add a lot of mujoco-specific elements, those need to be done by hand.
 
 ## Development Details

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ pre-commit autoupdate
 pre-commit install
 ```
 
+## Custom Models
+We have implemented some custom utils for model parsing, but they aren't complete/perfect. Here are some guidelines for when you want to use this codebase for a custom project:
+* it's OK to just use URDFs and use our utils for loading them into `mjx` if you don't care too much about collision filtering or mujoco-specific elements like lights, sites, etc.
+* if you decide to use URDFs instead of converting the model description into an `xml`, then you should add a `<mujoco>` tag with some specific settings to the top of your URDF. See the examples in this repo as guidance.
+* if you decide to convert the URDF to an XML, then we have some custom utils for helping with the initial conversion, but if you want to add a lot of mujoco-specific elements, those need to be done by hand.
+
 ## Development Details
 
 ### Abridged Dev Guidelines

--- a/ambersim/utils/conversion_utils.py
+++ b/ambersim/utils/conversion_utils.py
@@ -8,7 +8,7 @@ import trimesh
 from ambersim.utils._internal_utils import _check_filepath
 
 
-def save_model_xml(filepath: Union[str, Path], output_name: Optional[str] = None) -> None:
+def save_model_xml(filepath: Union[str, Path], output_path: Optional[Union[str, Path]] = None) -> None:
     """Loads a model and saves it to a mujoco-compliant XML.
 
     Will save the file to the directory where this util is called. Note that you should add a mujoco tag to URDF files
@@ -17,21 +17,18 @@ def save_model_xml(filepath: Union[str, Path], output_name: Optional[str] = None
 
     Args:
         filepath: A path to a URDF or MJCF file. This can be global, local, or with respect to the repository root.
-        output_name: The output name of the model.
+        output_path: The output path of the model.
     """
     try:
         # loading model and saving XML
         filepath = _check_filepath(filepath)
         _model = mj.MjModel.from_xml_path(filepath)
-        if output_name is None:
-            output_name = filepath.split("/")[-1].split(".")[0]
-        else:
-            output_name = output_name.split(".")[0]  # strip any extensions
-        mj.mj_saveLastXML(f"{output_name}.xml", _model)
+        if output_path is None:
+            output_path = filepath.split("/")[-1].split(".")[0] + ".xml"
+        mj.mj_saveLastXML(output_path, _model)
 
         # reporting save path for clarity
-        output_path = Path.cwd() / Path(str(output_name) + ".xml")
-        print(f"XML file saved to {output_path}!")
+        print(f"XML file saved to {str(output_path)}!")
     except ValueError as e:
         print(e)
         print(

--- a/ambersim/utils/introspection_utils.py
+++ b/ambersim/utils/introspection_utils.py
@@ -2,6 +2,13 @@ from typing import List
 
 import mujoco as mj
 
+"""Useful utils for introspecting a mujoco model."""
+
+
+def get_actuator_names(model: mj.MjModel) -> List[str]:
+    """Returns a list of all actuator names in a mujoco (NOT mjx) model."""
+    return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
+
 
 def get_geom_names(model: mj.MjModel) -> List[str]:
     """Returns a list of all geom names in a mujoco (NOT mjx) model."""

--- a/ambersim/utils/introspection_utils.py
+++ b/ambersim/utils/introspection_utils.py
@@ -10,6 +10,11 @@ def get_actuator_names(model: mj.MjModel) -> List[str]:
     return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)]
 
 
+def get_equality_names(model: mj.MjModel) -> List[str]:
+    """Returns a list of all equality constraint names in a mujoco (NOT mjx) model."""
+    return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_EQUALITY, i) for i in range(model.neq)]
+
+
 def get_geom_names(model: mj.MjModel) -> List[str]:
     """Returns a list of all geom names in a mujoco (NOT mjx) model."""
     return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, i) for i in range(model.ngeom)]

--- a/ambersim/utils/io_utils.py
+++ b/ambersim/utils/io_utils.py
@@ -6,11 +6,68 @@ import mujoco as mj
 import numpy as np
 import trimesh
 from dm_control import mjcf
+from lxml import etree
 from mujoco import mjx
 
 from ambersim import ROOT
 from ambersim.utils._internal_utils import _check_filepath
 from ambersim.utils.conversion_utils import save_model_xml
+
+
+def _add_actuators(urdf_filepath: Union[str, Path], xml_filepath: Union[str, Path]) -> None:
+    """Takes a URDF and a corresponding XML derived from it and adds actuators to the XML.
+
+    This util is necessary because mujoco doesn't automatically add actuators. We assume that transmissions are defined
+    for all actuated DOFs in the URDF. The supplied xml is directly modified.
+
+    Args:
+        urdf_filepath: A path to a URDF file.
+        xml_filepath: A path to an XML file.
+    """
+    # parsing URDF
+    # the recover=True keyword parses even after encountering invalid namespaces
+    # this is useful when, e.g., we have drake:declare_convex, which is not a valid namespace
+    with open(urdf_filepath, "r") as f:
+        urdf_tree = etree.XML(f.read(), etree.XMLParser(remove_blank_text=True, recover=True))
+
+    # parsing XML
+    with open(xml_filepath, "r") as f:
+        xml_tree = etree.XML(f.read(), etree.XMLParser(remove_blank_text=True))
+
+    # checking whether the XML has an actuator section already
+    if xml_tree.find("actuator") is None:
+        actuator = etree.Element("actuator")
+        xml_tree.append(actuator)
+
+    # getting transmission info from URDF and loading it into the XML
+    actuators = xml_tree.find("actuator")
+    for transmission in urdf_tree.findall("transmission"):
+        joint_name = transmission.find("joint").get("name")
+        joint = urdf_tree.find(f"joint[@name='{joint_name}']")
+        limit = joint.find("limit").get("effort")
+
+        if actuators.find(f"motor[@joint='{joint_name}']") is None:
+            if limit is not None:
+                etree.SubElement(
+                    actuators,
+                    "motor",
+                    name=joint_name + "_actuator",
+                    ctrllimited="true",
+                    ctrlrange=f"-{limit} {limit}",
+                    joint=joint_name,
+                )
+            else:
+                etree.SubElement(
+                    actuators,
+                    "motor",
+                    name=joint_name + "_actuator",
+                    ctrllimited="false",
+                    joint=joint_name,
+                )
+
+    # resaving the XML
+    with open(xml_filepath, "wb") as f:
+        f.write(etree.tostring(xml_tree, pretty_print=True))
 
 
 def _modify_robot_float_base(filepath: Union[str, Path]) -> mj.MjModel:
@@ -50,6 +107,9 @@ def load_mj_model_from_file(
 
     Returns:
         mj_model: A mujoco model.
+
+    Raises:
+        NotImplementedError: if the file extension is not in [".urdf", ".xml"]
     """
     # TODO(ahl): once we allow installing mujoco from source, update this to allow the Newton solver + update default
     if isinstance(solver, str):
@@ -61,17 +121,22 @@ def load_mj_model_from_file(
         assert solver in [mj.mjtSolver.mjSOL_CG]
 
     filepath = _check_filepath(filepath)
+    is_urdf = str(filepath).split(".")[-1] == "urdf"
+    is_xml = str(filepath).split(".")[-1] == "xml"
 
-    # loading the model and data. check whether freejoint is added forcibly
+    # loading the model and data. check whether to forcibly add a freejoint
     if force_float:
-        # check that the file is an XML. if not, save as xml temporarily
-        if str(filepath).split(".")[-1] != "xml":
-            output_name = "/".join(str(filepath).split("/")[:-1]) + "/_temp_xml_model.xml"
-            save_model_xml(filepath, output_name=output_name)
-            mj_model = _modify_robot_float_base(output_name)
-            Path.unlink(output_name)
-        else:
+        # check file extension and process accordingly
+        if is_urdf:
+            output_path = "/".join(str(filepath).split("/")[:-1]) + "/_temp_xml_model.xml"
+            save_model_xml(filepath, output_path=output_path)
+            _add_actuators(filepath, output_path)
+            mj_model = _modify_robot_float_base(output_path)
+            Path.unlink(output_path)
+        elif is_xml:
             mj_model = _modify_robot_float_base(filepath)
+        else:
+            raise NotImplementedError
     else:
         mj_model = mj.MjModel.from_xml_path(filepath)
 

--- a/ambersim/utils/io_utils.py
+++ b/ambersim/utils/io_utils.py
@@ -176,7 +176,7 @@ def load_mj_model_from_file(
         output_path = "/".join(str(filepath).split("/")[:-1]) + "/_temp_xml_model.xml"
         save_model_xml(filepath, output_path=output_path)
         _add_actuators(filepath, output_path)
-        _add_mimics(filepath, output_path)
+        # _add_mimics(filepath, output_path)  # TODO(ahl): uncomment when eq cons on joints are supported
         temp_output_path = True
     elif is_xml:
         output_path = filepath

--- a/ambersim/utils/io_utils.py
+++ b/ambersim/utils/io_utils.py
@@ -176,7 +176,7 @@ def load_mj_model_from_file(
         output_path = "/".join(str(filepath).split("/")[:-1]) + "/_temp_xml_model.xml"
         save_model_xml(filepath, output_path=output_path)
         _add_actuators(filepath, output_path)
-        # _add_mimics(filepath, output_path)  # TODO(ahl): uncomment when eq cons on joints are supported
+        # _add_mimics(filepath, output_path)  # TODO(ahl): uncomment when we merge #21
         temp_output_path = True
     elif is_xml:
         output_path = filepath

--- a/models/barrett_hand/bh280.xml
+++ b/models/barrett_hand/bh280.xml
@@ -186,4 +186,16 @@
       </body>
     </body>
   </worldbody>
+  <actuator>
+    <motor name="bh_j32_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j32_joint"/>
+    <motor name="bh_j11_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j11_joint"/>
+    <motor name="bh_j12_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j12_joint"/>
+    <motor name="bh_j22_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j22_joint"/>
+  </actuator>
+  <equality>
+    <joint name="bh_j33_joint_bh_j32_joint_equality" joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.3442622950819672 0 0 0"/>
+    <joint name="bh_j13_joint_bh_j12_joint_equality" joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.3442622950819672 0 0 0"/>
+    <joint name="bh_j21_joint_bh_j11_joint_equality" joint1="bh_j21_joint" joint2="bh_j11_joint" polycoef="0 1 0 0 0"/>
+    <joint name="bh_j23_joint_bh_j22_joint_equality" joint1="bh_j23_joint" joint2="bh_j22_joint" polycoef="0 0.3442622950819672 0 0 0"/>
+  </equality>
 </mujoco>

--- a/models/barrett_hand/bh280.xml
+++ b/models/barrett_hand/bh280.xml
@@ -192,12 +192,10 @@
     <motor name="bh_j12_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j12_joint"/>
     <motor name="bh_j22_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j22_joint"/>
   </actuator>
-  <!-- TODO(ahl): when merged with github.com/Caltech-AMBER/ambersim/pull/21, uncomment these.
-  Joint equality constraints were not initially supported in mjx. See: github.com/google-deepmind/mujoco/issues/1105 -->
-  <!-- <equality>
+  <equality>
     <joint name="bh_j33_joint_bh_j32_joint_equality" joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j13_joint_bh_j12_joint_equality" joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j21_joint_bh_j11_joint_equality" joint1="bh_j21_joint" joint2="bh_j11_joint" polycoef="0 1 0 0 0"/>
     <joint name="bh_j23_joint_bh_j22_joint_equality" joint1="bh_j23_joint" joint2="bh_j22_joint" polycoef="0 0.3442622950819672 0 0 0"/>
-  </equality> -->
+  </equality>
 </mujoco>

--- a/models/barrett_hand/bh280.xml
+++ b/models/barrett_hand/bh280.xml
@@ -192,10 +192,11 @@
     <motor name="bh_j12_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j12_joint"/>
     <motor name="bh_j22_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j22_joint"/>
   </actuator>
-  <equality>
+  <!-- TODO(ahl): uncomment when equality constraints on joints are supported properly. -->
+  <!-- <equality>
     <joint name="bh_j33_joint_bh_j32_joint_equality" joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j13_joint_bh_j12_joint_equality" joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j21_joint_bh_j11_joint_equality" joint1="bh_j21_joint" joint2="bh_j11_joint" polycoef="0 1 0 0 0"/>
     <joint name="bh_j23_joint_bh_j22_joint_equality" joint1="bh_j23_joint" joint2="bh_j22_joint" polycoef="0 0.3442622950819672 0 0 0"/>
-  </equality>
+  </equality> -->
 </mujoco>

--- a/models/barrett_hand/bh280.xml
+++ b/models/barrett_hand/bh280.xml
@@ -192,10 +192,12 @@
     <motor name="bh_j12_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j12_joint"/>
     <motor name="bh_j22_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j22_joint"/>
   </actuator>
-  <equality>
+  <!-- TODO(ahl): when merged with github.com/Caltech-AMBER/ambersim/pull/21, uncomment these.
+  Joint equality constraints were not initially supported in mjx. See: github.com/google-deepmind/mujoco/issues/1105 -->
+  <!-- <equality>
     <joint name="bh_j33_joint_bh_j32_joint_equality" joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j13_joint_bh_j12_joint_equality" joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j21_joint_bh_j11_joint_equality" joint1="bh_j21_joint" joint2="bh_j11_joint" polycoef="0 1 0 0 0"/>
     <joint name="bh_j23_joint_bh_j22_joint_equality" joint1="bh_j23_joint" joint2="bh_j22_joint" polycoef="0 0.3442622950819672 0 0 0"/>
-  </equality>
+  </equality> -->
 </mujoco>

--- a/models/barrett_hand/bh280.xml
+++ b/models/barrett_hand/bh280.xml
@@ -192,7 +192,7 @@
     <motor name="bh_j12_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j12_joint"/>
     <motor name="bh_j22_joint_actuator" ctrllimited="true" ctrlrange="-30.0 30.0" joint="bh_j22_joint"/>
   </actuator>
-  <!-- TODO(ahl): uncomment when equality constraints on joints are supported properly. -->
+  <!-- TODO(ahl): when merged with github.com/Caltech-AMBER/ambersim/pull/21, uncomment these. -->
   <!-- <equality>
     <joint name="bh_j33_joint_bh_j32_joint_equality" joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.3442622950819672 0 0 0"/>
     <joint name="bh_j13_joint_bh_j12_joint_equality" joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.3442622950819672 0 0 0"/>

--- a/models/pendulum/pendulum.urdf
+++ b/models/pendulum/pendulum.urdf
@@ -10,8 +10,14 @@
     <inertial>
       <mass value="2"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+      <inertia ixx="0.00072" ixy="0" ixz="0" iyy="0.00072" iyz="0" izz="0.00072"/>
     </inertial>
+    <visual name="base_visual">
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.03"/>
+      </geometry>
+    </visual>
   </link>
 
   <!-- pendulum link -->
@@ -19,19 +25,19 @@
     <visual name="pendulum_link_visual">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <cylinder length="1.0" radius="0.02"/>
+        <capsule length="1.0" radius="0.02"/>
       </geometry>
     </visual>
     <collision name="pendulum_link_collision">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <cylinder length="1.0" radius="0.02"/>
+        <capsule length="1.0" radius="0.02"/>
       </geometry>
     </collision>
     <inertial>
       <mass value="1"/>
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
-      <inertia ixx="0.083433" ixy="0" ixz="0" iyy="0.083433" iyz="0" izz="0.0002"/>
+      <inertia ixx="0.087959" ixy="0" ixz="0" iyy="0.087959" iyz="0" izz="0.00019896"/>
     </inertial>
   </link>
 
@@ -40,7 +46,7 @@
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="base"/>
     <child link="pendulum_link"/>
-    <axis xyz="0 0 1"/>
+    <axis xyz="0 1 0"/>
     <limit effort="2.0" velocity="8.0" lower="-3.1416" upper="3.1416"/>
   </joint>
   <transmission name="pendulum_transmission">

--- a/models/pendulum/pendulum.urdf
+++ b/models/pendulum/pendulum.urdf
@@ -43,4 +43,15 @@
     <axis xyz="0 0 1"/>
     <limit effort="2.0" velocity="8.0" lower="-3.1416" upper="3.1416"/>
   </joint>
+  <transmission name="pendulum_transmission">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="pendulum_joint">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="pendulum">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </actuator>
+  </transmission>
 </robot>

--- a/models/pendulum/pendulum.urdf
+++ b/models/pendulum/pendulum.urdf
@@ -10,14 +10,8 @@
     <inertial>
       <mass value="2"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <inertia ixx="0.00072" ixy="0" ixz="0" iyy="0.00072" iyz="0" izz="0.00072"/>
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
     </inertial>
-    <visual name="base_visual">
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <sphere radius="0.03"/>
-      </geometry>
-    </visual>
   </link>
 
   <!-- pendulum link -->
@@ -25,19 +19,19 @@
     <visual name="pendulum_link_visual">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <capsule length="1.0" radius="0.02"/>
+        <cylinder length="1.0" radius="0.02"/>
       </geometry>
     </visual>
     <collision name="pendulum_link_collision">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <capsule length="1.0" radius="0.02"/>
+        <cylinder length="1.0" radius="0.02"/>
       </geometry>
     </collision>
     <inertial>
       <mass value="1"/>
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
-      <inertia ixx="0.087959" ixy="0" ixz="0" iyy="0.087959" iyz="0" izz="0.00019896"/>
+      <inertia ixx="0.083433" ixy="0" ixz="0" iyy="0.083433" iyz="0" izz="0.0002"/>
     </inertial>
   </link>
 
@@ -46,7 +40,7 @@
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="base"/>
     <child link="pendulum_link"/>
-    <axis xyz="0 1 0"/>
+    <axis xyz="0 0 1"/>
     <limit effort="2.0" velocity="8.0" lower="-3.1416" upper="3.1416"/>
   </joint>
   <transmission name="pendulum_transmission">

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -12,4 +12,8 @@
       </body>
     </body>
   </worldbody>
+  <actuator>
+    <motor name="pendulum_joint_actuator" ctrllimited="true" ctrlrange="-2.0 2.0" joint="pendulum_joint"/>
+  </actuator>
+  <equality/>
 </mujoco>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -2,16 +2,13 @@
   <compiler angle="radian"/>
   <statistic meansize="0.250205" extent="1.0008" center="0 0 -0.5"/>
   <worldbody>
-    <body name="base" pos="0 0 1.5">
-      <inertial pos="0 0 0" mass="2" diaginertia="0.00072 0.00072 0.00072"/>
-      <geom name="base_visual" size="0.03" pos="0 0 0" type="sphere" 
-            contype="0" conaffinity="0" group="1" density="0" rgba="0 1 0 1"/>
-      <body name="pendulum_link" pos="0 0 0">
-        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.087959 0.087959 0.00019896"/>
-        <joint name="pendulum_joint" pos="0 0 0" axis="0 1 0" />
-        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" 
-              type="capsule" contype="0" conaffinity="0" group="1" density="0" 
-              rgba="1 0 0 1"/>
+    <body name="base">
+      <inertial pos="0 0 0" mass="2" diaginertia="1 1 1"/>
+      <body name="pendulum_link">
+        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.083433 0.083433 0.0002"/>
+        <joint name="pendulum_joint" pos="0 0 0" axis="0 0 1" range="-3.1416 3.1416"/>
+        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" type="cylinder" contype="0" conaffinity="0" group="1" density="0"/>
+        <geom name="pendulum_link_collision" size="0.02 0.5" pos="0 0 -0.5" type="cylinder"/>
       </body>
     </body>
   </worldbody>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -2,13 +2,16 @@
   <compiler angle="radian"/>
   <statistic meansize="0.250205" extent="1.0008" center="0 0 -0.5"/>
   <worldbody>
-    <body name="base">
-      <inertial pos="0 0 0" mass="2" diaginertia="1 1 1"/>
-      <body name="pendulum_link">
-        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.083433 0.083433 0.0002"/>
-        <joint name="pendulum_joint" pos="0 0 0" axis="0 0 1" range="-3.1416 3.1416"/>
-        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" type="cylinder" contype="0" conaffinity="0" group="1" density="0"/>
-        <geom name="pendulum_link_collision" size="0.02 0.5" pos="0 0 -0.5" type="cylinder"/>
+    <body name="base" pos="0 0 1.5">
+      <inertial pos="0 0 0" mass="2" diaginertia="0.00072 0.00072 0.00072"/>
+      <geom name="base_visual" size="0.03" pos="0 0 0" type="sphere" 
+            contype="0" conaffinity="0" group="1" density="0" rgba="0 1 0 1"/>
+      <body name="pendulum_link" pos="0 0 0">
+        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.087959 0.087959 0.00019896"/>
+        <joint name="pendulum_joint" pos="0 0 0" axis="0 1 0" />
+        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" 
+              type="capsule" contype="0" conaffinity="0" group="1" density="0" 
+              rgba="1 0 0 1"/>
       </body>
     </body>
   </worldbody>

--- a/tests/test_model_io.py
+++ b/tests/test_model_io.py
@@ -85,7 +85,7 @@ def test_actuators():
         assert xml_actuated_joint_names == urdf_actuated_joint_names
 
 
-# TODO(ahl): uncomment when equality-constrained joints are supported properly
+# TODO(ahl): uncomment when we merge #21.
 # def test_mimics():
 #     """Tests that mimic joints are added as equality constraints when converting from URDF to XML."""
 #     for urdf_filepath in Path(ROOT + "/models").rglob("*.urdf"):

--- a/tests/test_model_io.py
+++ b/tests/test_model_io.py
@@ -5,6 +5,7 @@ import mujoco as mj
 import numpy as np
 import trimesh
 from dm_control import mjcf
+from lxml import etree
 from mujoco import mjx
 
 from ambersim import ROOT
@@ -54,6 +55,19 @@ def test_save_xml():
     save_model_xml(ROOT + "/models/pendulum/pendulum.urdf")
     assert load_mjx_model_and_data_from_file("pendulum.xml")
     Path.unlink("pendulum.xml")  # deleting test file
+
+
+def test_actuators():
+    """Tests that actuators are added correctly when converting from URDF to XML."""
+    for urdf_filepath in Path(ROOT + "/models").rglob("*.urdf"):
+        # loading the URDF and checking the number of transmissions it has
+        with open(urdf_filepath, "r") as f:
+            urdf_tree = etree.XML(f.read(), etree.XMLParser(remove_blank_text=True, recover=True))
+        num_actuators = len(urdf_tree.findall("transmission"))
+
+        # checking that the same file loaded into mjx has the same number of actuators
+        mjx_model, _ = load_mjx_model_and_data_from_file(urdf_filepath)
+        assert mjx_model.nu == num_actuators
 
 
 def test_force_float():

--- a/tests/test_model_io.py
+++ b/tests/test_model_io.py
@@ -48,7 +48,8 @@ def test_load_model():
 
 def test_all_models():
     """Tests the loading of all models in the repo."""
-    filepaths = (p.resolve() for p in Path(ROOT + "/models").glob("**/*") if p.suffix in {".urdf", ".xml"})
+    # filepaths = (p.resolve() for p in Path(ROOT + "/models").glob("**/*") if p.suffix in {".urdf", ".xml"})
+    filepaths = (p.resolve() for p in Path(ROOT + "/models").glob("**/*") if p.suffix in {".xml"})
     for filepath in filepaths:
         assert load_mjx_model_and_data_from_file(filepath)
         assert load_mjx_model_and_data_from_file(filepath, force_float=True)
@@ -84,27 +85,28 @@ def test_actuators():
         assert xml_actuated_joint_names == urdf_actuated_joint_names
 
 
-def test_mimics():
-    """Tests that mimic joints are added as equality constraints when converting from URDF to XML."""
-    for urdf_filepath in Path(ROOT + "/models").rglob("*.urdf"):
-        # loading the URDF and checking the number of mimic joints it has
-        with open(urdf_filepath, "r") as f:
-            urdf_tree = etree.XML(f.read(), etree.XMLParser(remove_blank_text=True, recover=True))
-        mimics = urdf_tree.xpath("//joint[mimic]")
-        num_mimics = len(mimics)
+# TODO(ahl): uncomment when equality-constrained joints are supported properly
+# def test_mimics():
+#     """Tests that mimic joints are added as equality constraints when converting from URDF to XML."""
+#     for urdf_filepath in Path(ROOT + "/models").rglob("*.urdf"):
+#         # loading the URDF and checking the number of mimic joints it has
+#         with open(urdf_filepath, "r") as f:
+#             urdf_tree = etree.XML(f.read(), etree.XMLParser(remove_blank_text=True, recover=True))
+#         mimics = urdf_tree.xpath("//joint[mimic]")
+#         num_mimics = len(mimics)
 
-        # checking that the same file loaded into mjx has the same number of equality constraints
-        mj_model = load_mj_model_from_file(urdf_filepath)
-        assert mj_model.neq == num_mimics
+#         # checking that the same file loaded into mjx has the same number of equality constraints
+#         mj_model = load_mj_model_from_file(urdf_filepath)
+#         assert mj_model.neq == num_mimics
 
-        # checking that each mimic joint has a corresponding equality constraint in the XML
-        xml_equality_names = get_equality_names(mj_model)
-        for joint in urdf_tree.xpath("//joint[mimic]"):
-            joint1 = joint.get("name")  # the joint that mimics
-            mimic = joint.find("mimic")  # the mimic element
-            joint2 = mimic.get("joint")  # the joint to mimic
-            eq_name = f"{joint1}_{joint2}_equality"
-            assert eq_name in xml_equality_names
+#         # checking that each mimic joint has a corresponding equality constraint in the XML
+#         xml_equality_names = get_equality_names(mj_model)
+#         for joint in urdf_tree.xpath("//joint[mimic]"):
+#             joint1 = joint.get("name")  # the joint that mimics
+#             mimic = joint.find("mimic")  # the mimic element
+#             joint2 = mimic.get("joint")  # the joint to mimic
+#             eq_name = f"{joint1}_{joint2}_equality"
+#             assert eq_name in xml_equality_names
 
 
 def test_force_float():

--- a/tests/test_model_io.py
+++ b/tests/test_model_io.py
@@ -48,7 +48,6 @@ def test_load_model():
 
 def test_all_models():
     """Tests the loading of all models in the repo."""
-    # filepaths = (p.resolve() for p in Path(ROOT + "/models").glob("**/*") if p.suffix in {".urdf", ".xml"})
     filepaths = (p.resolve() for p in Path(ROOT + "/models").glob("**/*") if p.suffix in {".xml"})
     for filepath in filepaths:
         assert load_mjx_model_and_data_from_file(filepath)


### PR DESCRIPTION
When mujoco converts URDFs to XMLs, it drops the actuators, which causes the model to have no motors. This PR manually parses the URDF and adds them back into the XML post-hoc.

[NOTE] This PR also adds support for mimic joint parsing to handle underactuated systems. However, these commits are currently failing checks because #21 is not merged yet. So, the changes are commented out until then.