### PR TITLE
Add interactive simulation example

### DIFF
--- a/examples/interactive_simulation.py
+++ b/examples/interactive_simulation.py
@@ -12,7 +12,7 @@ system through the GUI.
 """
 
 
-def swingup_controller(theta, theta_dot):
+def swingup_controller(theta: float, theta_dot: float) -> float:
     """A simple swingup controller for the pendulum.
 
     Adopted from https://underactuated.mit.edu/pend.html#section3.

--- a/examples/interactive_simulation.py
+++ b/examples/interactive_simulation.py
@@ -47,7 +47,7 @@ def swingup_controller(theta: float, theta_dot: float) -> float:
 
 if __name__ == "__main__":
     # Create the model
-    mj_model = load_mj_model_from_file("models/pendulum/pendulum.xml")
+    mj_model = load_mj_model_from_file("models/pendulum/scene.xml")
     mj_data = mujoco.MjData(mj_model)
 
     # Set the initial state

--- a/examples/interactive_simulation.py
+++ b/examples/interactive_simulation.py
@@ -1,0 +1,76 @@
+import time
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+
+from ambersim.utils.io_utils import load_mj_model_from_file
+
+"""Example of launching an interactive simulation with a custom controller in
+mujoco. The controller keeps running, while the user can interact with the
+system through the GUI.
+"""
+
+
+def swingup_controller(theta, theta_dot):
+    """A simple swingup controller for the pendulum.
+
+    Adopted from https://underactuated.mit.edu/pend.html#section3.
+
+    Args:
+        theta: The angle of the pendulum, in radians (zero is down).
+        theta_dot: Velocity, in radians per second.
+
+    Returns:
+        tau: The control torque to apply.
+    """
+    # Approximate model: note that this is not an exact match for the sim.
+    m = 1.0  # mass
+    l = 0.7  # length
+    g = 9.81  # gravity
+
+    if np.cos(theta) > -0.9:
+        # Use an energy shaping controller to pump the pendulum up
+        desired_energy = m * g * l
+        energy = 0.5 * m * l**2 * theta_dot**2 - m * g * l * np.cos(theta)
+        k = 0.01
+        tau = -k * theta_dot * (energy - desired_energy)
+    else:
+        # Switch to a PD controller near the top
+        kp = 1.0
+        kd = 0.5
+        theta_err = np.arctan2(np.sin(theta - np.pi), np.cos(theta - np.pi))
+        tau = -kp * theta_err - kd * theta_dot
+
+    return tau
+
+
+if __name__ == "__main__":
+    # Create the model
+    mj_model = load_mj_model_from_file("models/pendulum/pendulum.xml")
+    mj_data = mujoco.MjData(mj_model)
+
+    # Set the initial state
+    mj_data.qpos[:] = 0.01
+
+    # Launch the viewer
+    with mujoco.viewer.launch_passive(mj_model, mj_data) as viewer:
+        while viewer.is_running():
+            step_start = time.time()
+
+            # Compute the control signal
+            theta = mj_data.qpos[0]
+            theta_dot = mj_data.qvel[0]
+            tau = swingup_controller(theta, theta_dot)
+            mj_data.ctrl[0] = tau
+
+            # Step the simulation forward
+            mujoco.mj_step(mj_model, mj_data)
+
+            # Sync data from the viewer with the simulation
+            viewer.sync()
+
+            # Try to run in roughly real time
+            elapsed = time.time() - step_start
+            if elapsed < mj_model.opt.timestep:
+                time.sleep(mj_model.opt.timestep - elapsed)

--- a/examples/interactive_simulation.py
+++ b/examples/interactive_simulation.py
@@ -33,12 +33,12 @@ def swingup_controller(theta: float, theta_dot: float) -> float:
         # Use an energy shaping controller to pump the pendulum up
         desired_energy = m * g * l
         energy = 0.5 * m * l**2 * theta_dot**2 - m * g * l * np.cos(theta)
-        k = 0.01
+        k = 0.1
         tau = -k * theta_dot * (energy - desired_energy)
     else:
         # Switch to a PD controller near the top
-        kp = 1.0
-        kd = 0.5
+        kp = 10.0
+        kd = 5.0
         theta_err = np.arctan2(np.sin(theta - np.pi), np.cos(theta - np.pi))
         tau = -kp * theta_err - kd * theta_dot
 

--- a/models/pendulum/pendulum.urdf
+++ b/models/pendulum/pendulum.urdf
@@ -10,8 +10,14 @@
     <inertial>
       <mass value="2"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+      <inertia ixx="0.00072" ixy="0" ixz="0" iyy="0.00072" iyz="0" izz="0.00072"/>
     </inertial>
+    <visual name="base_visual">
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.03"/>
+      </geometry>
+    </visual>
   </link>
 
   <!-- pendulum link -->
@@ -19,19 +25,19 @@
     <visual name="pendulum_link_visual">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <cylinder length="1.0" radius="0.02"/>
+        <capsule length="1.0" radius="0.02"/>
       </geometry>
     </visual>
     <collision name="pendulum_link_collision">
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
       <geometry>
-        <cylinder length="1.0" radius="0.02"/>
+        <capsule length="1.0" radius="0.02"/>
       </geometry>
     </collision>
     <inertial>
       <mass value="1"/>
       <origin rpy="0 0 0" xyz="0 0 -0.5"/>
-      <inertia ixx="0.083433" ixy="0" ixz="0" iyy="0.083433" iyz="0" izz="0.0002"/>
+      <inertia ixx="0.087959" ixy="0" ixz="0" iyy="0.087959" iyz="0" izz="0.00019896"/>
     </inertial>
   </link>
 
@@ -40,7 +46,7 @@
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="base"/>
     <child link="pendulum_link"/>
-    <axis xyz="0 0 1"/>
+    <axis xyz="0 1 0"/>
     <limit effort="2.0" velocity="8.0" lower="-3.1416" upper="3.1416"/>
   </joint>
 </robot>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -14,6 +14,6 @@
     </body>
   </worldbody>
   <actuator>
-    <motor joint="pendulum_joint"/>
+    <motor name="pendulum_joint_actuator" ctrllimited="true" ctrlrange="-2.0 2.0" joint="pendulum_joint"/>
   </actuator>
 </mujoco>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -1,18 +1,5 @@
 <mujoco model="pendulum">
-  <!-- Make some textures for the ground -->
-  <asset>
-    <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
-    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
-  </asset>
-
   <worldbody>
-    <!-- The floor -->
-    <geom name="floor" pos="0 0 0" size="0 0 .05" type="plane" material="grid" condim="3"/>
-
-    <!-- Some light -->
-    <light name="spotlight" diffuse=".8 .8 .8" specular="0.2 0.2 0.2" pos="0 -1 2" cutoff="1000"/>
-
-    <!-- The actual pendulum model -->
     <body name="base" pos="0 0 0">
       <!-- Dummy base inertia: for parser testing only -->
       <inertial pos="0 0 0" mass="2" diaginertia="1 1 1"/>
@@ -25,10 +12,7 @@
       </body>
     </body>
   </worldbody>
-
-  <!-- The actuator -->
   <actuator>
     <motor gear="10" joint="pendulum_joint"/>
   </actuator>
-
 </mujoco>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -1,13 +1,14 @@
 <mujoco model="pendulum">
   <worldbody>
-    <body name="base" pos="0 0 0">
-      <!-- Dummy base inertia: for parser testing only -->
-      <inertial pos="0 0 0" mass="2" diaginertia="1 1 1"/>
-      <body name="pendulum_link" pos="0 0 1.5">
-        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.083433 0.083433 0.0002"/>
+    <body name="base" pos="0 0 1.5">
+      <inertial pos="0 0 0" mass="2" diaginertia="0.00072 0.00072 0.00072"/>
+      <geom name="base_visual" size="0.03" pos="0 0 0" type="sphere" 
+            contype="0" conaffinity="0" group="1" density="0" rgba="0 1 0 1"/>
+      <body name="pendulum_link" pos="0 0 0">
+        <inertial pos="0 0 -0.5" mass="1" diaginertia="0.087959 0.087959 0.00019896"/>
         <joint name="pendulum_joint" pos="0 0 0" axis="0 1 0" />
         <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" 
-              type="cylinder" contype="0" conaffinity="0" group="1" density="0" 
+              type="capsule" contype="0" conaffinity="0" group="1" density="0" 
               rgba="1 0 0 1"/>
       </body>
     </body>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -1,15 +1,34 @@
 <mujoco model="pendulum">
-  <compiler angle="radian"/>
-  <statistic meansize="0.250205" extent="1.0008" center="0 0 -0.5"/>
+  <!-- Make some textures for the ground -->
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
+    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
+  </asset>
+
   <worldbody>
-    <body name="base">
+    <!-- The floor -->
+    <geom name="floor" pos="0 0 0" size="0 0 .05" type="plane" material="grid" condim="3"/>
+
+    <!-- Some light -->
+    <light name="spotlight" diffuse=".8 .8 .8" specular="0.2 0.2 0.2" pos="0 -1 2" cutoff="1000"/>
+
+    <!-- The actual pendulum model -->
+    <body name="base" pos="0 0 0">
+      <!-- Dummy base inertia: for parser testing only -->
       <inertial pos="0 0 0" mass="2" diaginertia="1 1 1"/>
-      <body name="pendulum_link">
+      <body name="pendulum_link" pos="0 0 1.5">
         <inertial pos="0 0 -0.5" mass="1" diaginertia="0.083433 0.083433 0.0002"/>
-        <joint name="pendulum_joint" pos="0 0 0" axis="0 0 1" range="-3.1416 3.1416"/>
-        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" type="cylinder" contype="0" conaffinity="0" group="1" density="0"/>
-        <geom name="pendulum_link_collision" size="0.02 0.5" pos="0 0 -0.5" type="cylinder"/>
+        <joint name="pendulum_joint" pos="0 0 0" axis="0 1 0" />
+        <geom name="pendulum_link_visual" size="0.02 0.5" pos="0 0 -0.5" 
+              type="cylinder" contype="0" conaffinity="0" group="1" density="0" 
+              rgba="1 0 0 1"/>
       </body>
     </body>
   </worldbody>
+
+  <!-- The actuator -->
+  <actuator>
+    <motor gear="10" joint="pendulum_joint"/>
+  </actuator>
+
 </mujoco>

--- a/models/pendulum/pendulum.xml
+++ b/models/pendulum/pendulum.xml
@@ -13,6 +13,6 @@
     </body>
   </worldbody>
   <actuator>
-    <motor gear="10" joint="pendulum_joint"/>
+    <motor joint="pendulum_joint"/>
   </actuator>
 </mujoco>

--- a/models/pendulum/scene.xml
+++ b/models/pendulum/scene.xml
@@ -1,0 +1,25 @@
+<mujoco model="pendulum_scene">
+
+  <include file="pendulum.xml"/>
+
+  <statistic center="0 0 0.55" extent="1.1"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1" directional="false"/>
+    <geom name="floor" size="0 0 .125" type="plane" material="groundplane" conaffinity="15" condim="3"/>
+  </worldbody>
+
+</mujoco>

--- a/models/pendulum/scene.xml
+++ b/models/pendulum/scene.xml
@@ -1,5 +1,5 @@
 <mujoco model="pendulum_scene">
-
+  <!-- Model that includes the pendulum along with scene details like lighting and a ground. -->
   <include file="pendulum.xml"/>
 
   <statistic center="0 0 0.55" extent="1.1"/>


### PR DESCRIPTION
Adds an example of running a mujoco simulation where the user can interact with the model while the controller is running. 

Also updates the `pendulum.xml` model so it looks good and swings properly. 