### PR TITLE
Minor fix to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,6 @@ This repository houses tools built on the GPU-accelerated simulation capabilitie
 * massively-parallelized simulation.
 
 ## Installation
-### Via `pip`
-There's currently no official pypi release, but you can still install this package via `pip`. We recommend installing it in a conda environment with Cuda 11.8 support.
-```
-# all development dependencies
-pip install "ambersim[all] @ git+https://github.com/Caltech-AMBER/ambersim.git" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-
-# barebones dependencies
-pip install "ambersim @ git+https://github.com/Caltech-AMBER/ambersim.git" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-```
-This package also installs a script that can help you optionally build and install `mujoco` from source to get the latest and greatest features and bugfixes between official releases.
-```
-install-mujoco-from-source [--hash <mujoco_commit_hash>] [--mujoco-dir /path/to/local/mujoco]
-```
-Both `--hash` and `--mujoco-dir` are optional arguments. If no hash is supplied, we pull the latest one. If no `mujoco` directory is supplied, we clone `mujoco` into `$HOME/mujoco`. We recommend pointing this to a reasonable location instead of using the default.
-
-In order to build `mujoco` successfully, you may need to install system-wide dependencies with the following commands:
-```
-sudo apt-get update
-sudo apt-get install -y \
-    libgl1-mesa-dev \
-    libxinerama-dev \
-    libxcursor-dev \
-    libxrandr-dev \
-    libxi-dev \
-    ninja-build
-```
-
 ### Local
 Clone this repository and run the following commands in the repository root to create and activate a conda environment with Cuda 11.8 support:
 ```
@@ -75,6 +48,33 @@ Further, you can examine the latest minor version using `pip`:
 ```
 pip show mujoco
 pip show mujoco-mjx
+```
+
+### Via `pip`
+There's currently no official pypi release, but you can still install this package via `pip`. We recommend installing it in a conda environment with Cuda 11.8 support.
+```
+# all development dependencies
+pip install "ambersim[all] @ git+https://github.com/Caltech-AMBER/ambersim.git" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+# barebones dependencies
+pip install "ambersim @ git+https://github.com/Caltech-AMBER/ambersim.git" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+```
+This package also installs a script that can help you optionally build and install `mujoco` from source to get the latest and greatest features and bugfixes between official releases.
+```
+install-mujoco-from-source [--hash <mujoco_commit_hash>] [--mujoco-dir /path/to/local/mujoco]
+```
+Both `--hash` and `--mujoco-dir` are optional arguments. If no hash is supplied, we pull the latest one. If no `mujoco` directory is supplied, we clone `mujoco` into `$HOME/mujoco`. We recommend pointing this to a reasonable location instead of using the default.
+
+In order to build `mujoco` successfully, you may need to install system-wide dependencies with the following commands:
+```
+sudo apt-get update
+sudo apt-get install -y \
+    libgl1-mesa-dev \
+    libxinerama-dev \
+    libxcursor-dev \
+    libxrandr-dev \
+    libxi-dev \
+    ninja-build
 ```
 
 ## Custom Models

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ conda activate <env_name>
 
 TL;DR: installation commands are here. This will ask you for your password to install system-wide dependencies. For details, see below.
 
-For non-developers installing `mujoco` from source:
+For non-developers installing `mujoco` from source, run the following in the repo root:
 ```
-./install.sh -s
+./ambersim/_scripts/install.sh -s
 ```
 
 For developers installing `mujoco` from source:
 ```
 # no path to the mujoco repo specified
-./install.sh -s -d
+./ambersim/_scripts/install.sh -s -d
 
 # specifying a path to the mujoco repo
-./install.sh -s -d --mujoco-dir /path/ending/in/mujoco
+./ambersim/_scripts/install.sh -s -d --mujoco-dir /path/ending/in/mujoco
 ```
 
 Installation of this package is done via the above `bash` script. There are a few flags for configuring the installation:


### PR DESCRIPTION
Instructions updated to point to the correct directory for the installation script.

Q: should we just suggest a two-step installation? One with `pip install` + all the relevant flags, then optionally tell the user to run the installed bash command `install_mujoco_from_src`. If we change the instructions to say this, then there's no difference between the installation via `pip` or locally, which is a plus.