### PR TITLE
Add wrappers for saving and loading brax PPO networks

### DIFF
--- a/ambersim/learning/architectures.py
+++ b/ambersim/learning/architectures.py
@@ -1,0 +1,32 @@
+from typing import Sequence
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+
+class MLP(nn.Module):
+    """A simple pickle-able multi-layer perceptron.
+
+    Args:
+        layer_sizes: Sizes of all hidden layers and the output layer.
+        activate_final: Whether to apply an activation function to the output.
+        bias: Whether to use a bias in the linear layers.
+    """
+
+    layer_sizes: Sequence[int]
+    activate_final: bool = False
+    bias: bool = True
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Forward pass through the network."""
+        # TODO(vincekurtz): consider using jax control flow here
+        for i, layer_size in enumerate(self.layer_sizes):
+            x = nn.Dense(
+                layer_size,
+                use_bias=self.bias,
+                name=f"dense_{i}",
+            )(x)
+            if i != len(self.layer_sizes) - 1 or self.activate_final:
+                x = nn.relu(x)
+        return x

--- a/ambersim/learning/architectures.py
+++ b/ambersim/learning/architectures.py
@@ -20,7 +20,9 @@ class MLP(nn.Module):
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         """Forward pass through the network."""
-        # TODO(vincekurtz): consider using jax control flow here
+        # TODO(vincekurtz): consider using jax control flow here. Note that
+        # standard jax control flows (e.g. jax.lax.scan) do not play nicely with
+        # flax, see for example https://github.com/google/flax/discussions/1283.
         for i, layer_size in enumerate(self.layer_sizes):
             x = nn.Dense(
                 layer_size,

--- a/ambersim/rl/helpers.py
+++ b/ambersim/rl/helpers.py
@@ -1,43 +1,9 @@
-from typing import Sequence
-
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from brax.training import distribution, networks, types
 from brax.training.agents.ppo.networks import PPONetworks
 from flax import struct
-
-"""
-Convienience tools for defining neural networks for RL.
-"""
-
-
-class MLP(nn.Module):
-    """A simple pickle-able multi-layer perceptron.
-
-    Args:
-        layer_sizes: Sizes of all hidden layers and the output layer.
-        activate_final: Whether to apply an activation function to the output.
-        bias: Whether to use a bias in the linear layers.
-    """
-
-    layer_sizes: Sequence[int]
-    activate_final: bool = False
-    bias: bool = True
-
-    @nn.compact
-    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-        """Forward pass through the network."""
-        # TODO(vincekurtz): consider using jax control flow here
-        for i, layer_size in enumerate(self.layer_sizes):
-            x = nn.Dense(
-                layer_size,
-                use_bias=self.bias,
-                name=f"dense_{i}",
-            )(x)
-            if i != len(self.layer_sizes) - 1 or self.activate_final:
-                x = nn.relu(x)
-        return x
 
 
 @struct.dataclass

--- a/ambersim/rl/networks.py
+++ b/ambersim/rl/networks.py
@@ -26,7 +26,7 @@ class MLP(nn.Module):
     bias: bool = True
 
     @nn.compact
-    def __call__(self, x):
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         """Forward pass through the network."""
         # TODO(vincekurtz): consider using jax control flow here
         for i, layer_size in enumerate(self.layer_sizes):

--- a/ambersim/rl/networks.py
+++ b/ambersim/rl/networks.py
@@ -1,0 +1,39 @@
+from typing import Sequence
+
+import flax.linen as nn
+import jax
+import jax.numpy as np
+from brax.training import distribution, networks, types
+from brax.training.agents.ppo.networks import PPONetworks
+
+"""
+Convienience tools for defining neural networks for RL.
+"""
+
+
+class MLP(nn.Module):
+    """A simple pickle-able multi-layer perceptron.
+
+    Args:
+        layer_sizes: Sizes of all hidden layers and the output layer.
+        activate_final: Whether to apply an activation function to the output.
+        bias: Whether to use a bias in the linear layers.
+    """
+
+    layer_sizes: Sequence[int]
+    activate_final: bool = False
+    bias: bool = True
+
+    @nn.compact
+    def __call__(self, x):
+        """Forward pass through the network."""
+        # TODO(vincekurtz): consider using jax control flow here
+        for i, layer_size in enumerate(self.layer_sizes):
+            x = nn.Dense(
+                layer_size,
+                use_bias=self.bias,
+                name=f"dense_{i}",
+            )(x)
+            if i != len(self.layer_sizes) - 1 or self.activate_final:
+                x = nn.relu(x)
+        return x

--- a/ambersim/rl/networks.py
+++ b/ambersim/rl/networks.py
@@ -2,9 +2,10 @@ from typing import Sequence
 
 import flax.linen as nn
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 from brax.training import distribution, networks, types
 from brax.training.agents.ppo.networks import PPONetworks
+from flax import struct
 
 """
 Convienience tools for defining neural networks for RL.
@@ -37,3 +38,80 @@ class MLP(nn.Module):
             if i != len(self.layer_sizes) - 1 or self.activate_final:
                 x = nn.relu(x)
         return x
+
+
+@struct.dataclass
+class BraxPPONetworksWrapper:
+    """A lightweight wrapper around brax's PPONetworks.
+
+    Allows us to more easily save and load networks with non-default architectures.
+    """
+
+    policy_network: nn.Module
+    value_network: nn.Module
+    action_distribution: distribution.ParametricDistribution
+
+    def make_ppo_networks(
+        self,
+        observation_size: int,
+        action_size: int,
+        preprocess_observations_fn: types.PreprocessObservationFn = types.identity_observation_preprocessor,
+    ) -> PPONetworks:
+        """Create a PPONetworks object, compatible with brax's ppo.train() function.
+
+        Args:
+            observation_size: Size of the input (observation).
+            action_size: Size of the policy output (action).
+            preprocess_observations_fn: Function to preprocess (e.g. normalize) observations.
+
+        Returns:
+            A PPONetworks object.
+        """
+        # Create an action distribution. The policy network should output the
+        # parameters of this distribution.
+        action_dist = self.action_distribution(event_size=action_size)
+
+        # Set up a dummy observation and random key for size verifications
+        dummy_observation = jnp.zeros((1, observation_size))
+        rng = jax.random.PRNGKey(0)
+
+        # Check that the output size of the policy network matches the size of
+        # the action distribution.
+        dummy_params = self.policy_network.init(rng, dummy_observation)
+        policy_output = self.policy_network.apply(dummy_params, dummy_observation)
+        assert (
+            policy_output.shape[-1] == action_dist.param_size
+        ), f"policy network output size {policy_output.shape[-1]} does not match action distribution size {action_dist.param_size}"
+
+        # Create the policy network, a FeedForwardNetwork that contains an "init"
+        # and an "apply" function.
+        def policy_init(key):
+            """Initialize the policy network from a random key."""
+            return self.policy_network.init(key, dummy_observation)
+
+        def policy_apply(processor_params, policy_params, obs):
+            """Apply the policy given the parameters and an observation."""
+            obs = preprocess_observations_fn(obs, processor_params)
+            return self.policy_network.apply(policy_params, obs)
+
+        # Create the value network. This is just like the policy network, but with a 1D output.
+        dummy_value_params = self.value_network.init(rng, dummy_observation)
+        value_output = self.value_network.apply(dummy_value_params, dummy_observation)
+        assert (
+            value_output.shape[-1] == 1
+        ), f"value network output size {value_output.shape} does not match expected size 1"
+
+        def value_init(key):
+            """Initialize the value network from a random key."""
+            return self.value_network.init(key, dummy_observation)
+
+        def value_apply(processor_params, value_params, obs):
+            """Apply the value function given the parameters and an observation."""
+            obs = preprocess_observations_fn(obs, processor_params)
+            return jnp.squeeze(self.value_network.apply(value_params, obs), axis=-1)
+
+        return PPONetworks(
+            policy_network=networks.FeedForwardNetwork(init=policy_init, apply=policy_apply),
+            value_network=networks.FeedForwardNetwork(init=value_init, apply=value_apply),
+            parametric_action_distribution=action_dist,
+        )

--- a/examples/rl/pendulum/ex_save_and_load.py
+++ b/examples/rl/pendulum/ex_save_and_load.py
@@ -1,0 +1,157 @@
+import functools
+import pickle
+import sys
+import time
+from datetime import datetime
+
+# Note: mujoco viewer must load before jax
+# isort: off
+import mujoco
+import mujoco.viewer
+
+# isort: on
+
+import jax
+from brax import envs
+from brax.io import model
+from brax.training import distribution
+from brax.training.acme import running_statistics
+from brax.training.agents.ppo import train as ppo
+from brax.training.agents.ppo.networks import make_inference_fn
+from mujoco import mjx
+
+from ambersim.rl.networks import MLP, BraxPPONetworksWrapper
+from ambersim.rl.pendulum.swingup import PendulumSwingupEnv
+
+"""
+Perform pendulum swingup training with custom policy architectures, and
+demonstrate saving and loading the trained networks from disk.
+"""
+
+
+def train_swingup():
+    """Train a pendulum swingup agent with custom network architectures."""
+    # Initialize the environment
+    envs.register_environment("pendulum_swingup", PendulumSwingupEnv)
+    env = envs.get_environment("pendulum_swingup")
+
+    # Create some funky custom network architectures
+    policy_network = MLP(layer_sizes=(512, 4, 128, 2))  # outputs mean and variance
+    value_network = MLP(layer_sizes=(26, 128, 53, 1))  # outputs a single value
+    network_wrapper = BraxPPONetworksWrapper(
+        policy_network=policy_network,
+        value_network=value_network,
+        action_distribution=distribution.NormalTanhDistribution,
+    )
+
+    train_fn = functools.partial(
+        ppo.train,
+        num_timesteps=100_000,
+        num_evals=50,
+        reward_scaling=0.1,
+        episode_length=200,
+        normalize_observations=True,
+        action_repeat=1,
+        unroll_length=10,
+        num_minibatches=32,
+        num_updates_per_batch=8,
+        discounting=0.97,
+        learning_rate=3e-4,
+        entropy_cost=0,
+        num_envs=1024,
+        batch_size=512,
+        network_factory=network_wrapper.make_ppo_networks,
+        seed=0,
+    )
+
+    # Define a callback to log progress
+    times = [datetime.now()]
+
+    def progress(num_steps, metrics):
+        """Logs progress during RL."""
+        print(f"  Steps: {num_steps}, Reward: {metrics['eval/episode_reward']}")
+        times.append(datetime.now())
+
+    # Do the training
+    print("Training...")
+    make_inference_fn, params, _ = train_fn(
+        environment=env,
+        progress_fn=progress,
+    )
+
+    print(f"Time to jit: {times[1] - times[0]}")
+    print(f"Time to train: {times[-1] - times[1]}")
+
+    # Save both the parameters and the networks to disk
+    print("Saving...")
+    params_path = "/tmp/pendulum_params.pkl"
+    networks_path = "/tmp/pendulum_networks.pkl"
+    model.save_params(params_path, params)
+    with open(networks_path, "wb") as f:
+        pickle.dump(network_wrapper, f)
+
+
+def test_trained_swingup_policy():
+    """Load a trained policy and run an interactive simulation."""
+    envs.register_environment("pendulum_swingup", PendulumSwingupEnv)
+    env = envs.get_environment("pendulum_swingup")
+    mj_model = env.model
+    mj_data = mujoco.MjData(mj_model)
+    obs = env.compute_obs(mjx.device_put(mj_data), {})
+
+    print("Loading trained policy...")
+    params_path = "/tmp/pendulum_params.pkl"
+    networks_path = "/tmp/pendulum_networks.pkl"
+    params = model.load_params(params_path)
+    with open(networks_path, "rb") as f:
+        network_wrapper = pickle.load(f)
+
+    # Create the policy
+    ppo_networks = network_wrapper.make_ppo_networks(
+        observation_size=env.observation_size,
+        action_size=env.action_size,
+        preprocess_observations_fn=running_statistics.normalize,
+    )
+
+    make_policy = make_inference_fn(ppo_networks)
+    policy = make_policy(params, deterministic=True)
+    jit_policy = jax.jit(policy)
+
+    print("Simulating...")
+    rng = jax.random.PRNGKey(0)
+    with mujoco.viewer.launch_passive(mj_model, mj_data) as viewer:
+        while viewer.is_running():
+            start_time = time.time()
+            act_rng, rng = jax.random.split(rng)
+
+            # Apply the policy
+            act, _ = jit_policy(obs, act_rng)
+            mj_data.ctrl[:] = act
+            obs = env.compute_obs(mjx.device_put(mj_data), {})
+
+            # Step the simulation
+            for _ in range(env._physics_steps_per_control_step):
+                mujoco.mj_step(mj_model, mj_data)
+                viewer.sync()
+
+            # Try to run in roughly realtime
+            elapsed = time.time() - start_time
+            dt = float(env.dt)
+            if elapsed < dt:
+                time.sleep(dt - elapsed)
+
+
+if __name__ == "__main__":
+    usage_message = "Usage: python ex_save_and_load.py [train|test]"
+
+    if len(sys.argv) != 2:
+        print(usage_message)
+        sys.exit(1)
+
+    if sys.argv[1] == "train":
+        train_swingup()
+    elif sys.argv[1] == "test":
+        test_trained_swingup_policy()
+    else:
+        print(usage_message)
+        sys.exit(1)

--- a/examples/rl/pendulum/ex_save_and_load.py
+++ b/examples/rl/pendulum/ex_save_and_load.py
@@ -4,14 +4,9 @@ import sys
 import time
 from datetime import datetime
 
-# Note: mujoco viewer must load before jax
-# isort: off
+import jax
 import mujoco
 import mujoco.viewer
-
-# isort: on
-
-import jax
 from brax import envs
 from brax.io import model
 from brax.training import distribution

--- a/examples/rl/pendulum/ex_save_and_load.py
+++ b/examples/rl/pendulum/ex_save_and_load.py
@@ -20,7 +20,8 @@ from brax.training.agents.ppo import train as ppo
 from brax.training.agents.ppo.networks import make_inference_fn
 from mujoco import mjx
 
-from ambersim.rl.networks import MLP, BraxPPONetworksWrapper
+from ambersim.learning.architectures import MLP
+from ambersim.rl.helpers import BraxPPONetworksWrapper
 from ambersim.rl.pendulum.swingup import PendulumSwingupEnv
 
 """

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -1,0 +1,74 @@
+import pickle
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+
+from ambersim.rl.networks import MLP
+from ambersim.utils._internal_utils import _rmtree
+
+
+def test_mlp_construction():
+    """Create a simple MLP and verify sizes."""
+    input_size = (3,)
+    layer_sizes = (2, 3, 4)
+
+    # Create the MLP
+    rng = jax.random.PRNGKey(0)
+    mlp = MLP(layer_sizes=layer_sizes, bias=True)
+    dummy_input = jnp.ones(input_size)
+    params = mlp.init(rng, dummy_input)
+
+    # Check the MLP's structure
+    print(mlp.tabulate(rng, dummy_input))
+
+    # Forward pass through the network
+    my_input = jax.random.normal(rng, input_size)
+    my_output = mlp.apply(params, my_input)
+    assert my_output.shape[-1] == layer_sizes[-1]
+
+    # Check number of parameters
+    num_params = sum(x.size for x in jax.tree_util.tree_leaves(params))
+    expected_num_params = 0
+    sizes = input_size + layer_sizes
+    for i in range(len(sizes) - 1):
+        expected_num_params += sizes[i] * sizes[i + 1]  # weights
+        expected_num_params += sizes[i + 1]  # biases
+    assert num_params == expected_num_params
+
+
+def test_mlp_save_load():
+    """Verify that we can pickle an MLP."""
+    rng = jax.random.PRNGKey(0)
+    mlp = MLP(layer_sizes=(2, 3, 4))
+    dummy_input = jnp.ones((3,))
+    params = mlp.init(rng, dummy_input)
+
+    original_output = mlp.apply(params, dummy_input)
+
+    # Create a temporary path for saving stuff
+    local_dir = Path("_test_mlp")
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save the MLP
+    model_path = local_dir / "mlp.pkl"
+    with Path(model_path).open("wb") as f:
+        pickle.dump(mlp, f)
+
+    # Save the parameters (weights)
+    params_path = local_dir / "params.pkl"
+    with Path(params_path).open("wb") as f:
+        pickle.dump(params, f)
+
+    # Load the MLP and parameters
+    with Path(model_path).open("rb") as f:
+        new_mlp = pickle.load(f)
+    with Path(params_path).open("rb") as f:
+        new_params = pickle.load(f)
+
+    # Check that the loaded MLP gives the same output
+    new_output = new_mlp.apply(new_params, dummy_input)
+    assert jnp.allclose(original_output, new_output)
+
+    # Remove the temporary directory
+    _rmtree(local_dir)

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -13,17 +13,19 @@ def test_mlp_construction():
     input_size = (3,)
     layer_sizes = (2, 3, 4)
 
+    # Pseudo-random keys
+    param_rng, tabulate_rng, input_rng = jax.random.split(jax.random.PRNGKey(0), 3)
+
     # Create the MLP
-    rng = jax.random.PRNGKey(0)
     mlp = MLP(layer_sizes=layer_sizes, bias=True)
     dummy_input = jnp.ones(input_size)
-    params = mlp.init(rng, dummy_input)
+    params = mlp.init(param_rng, dummy_input)
 
     # Check the MLP's structure
-    print(mlp.tabulate(rng, dummy_input))
+    print(mlp.tabulate(tabulate_rng, dummy_input))
 
     # Forward pass through the network
-    my_input = jax.random.normal(rng, input_size)
+    my_input = jax.random.normal(input_rng, input_size)
     my_output = mlp.apply(params, my_input)
     assert my_output.shape[-1] == layer_sizes[-1]
 

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 
-from ambersim.rl.networks import MLP
+from ambersim.learning.architectures import MLP
 from ambersim.utils._internal_utils import _rmtree
 
 

--- a/tests/test_ppo_networks.py
+++ b/tests/test_ppo_networks.py
@@ -1,0 +1,51 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from brax.training import distribution
+from brax.training.agents.ppo.networks import PPONetworks
+
+from ambersim.rl.networks import MLP, BraxPPONetworksWrapper
+from ambersim.utils._internal_utils import _rmtree
+
+
+def test_ppo_wrapper():
+    """Test the BraxPPONetworksWrapper."""
+    observation_size = 3
+    action_size = 2
+
+    with pytest.raises(AssertionError):
+        # We should get an error if the policy network's output doesn't match
+        # the size of the action distribution (mean + variance)
+        network_wrapper = BraxPPONetworksWrapper(
+            policy_network=MLP(layer_sizes=(512, 2)),
+            value_network=MLP(layer_sizes=(512, 1)),
+            action_distribution=distribution.NormalTanhDistribution,
+        )
+        network_wrapper.make_ppo_networks(
+            observation_size=observation_size,
+            action_size=action_size,
+        )
+
+    with pytest.raises(AssertionError):
+        # We should get an error if the value network's output isn't 1D
+        network_wrapper = BraxPPONetworksWrapper(
+            policy_network=MLP(layer_sizes=(512, 4)),
+            value_network=MLP(layer_sizes=(512, 2)),
+            action_distribution=distribution.NormalTanhDistribution,
+        )
+        network_wrapper.make_ppo_networks(
+            observation_size=observation_size,
+            action_size=action_size,
+        )
+
+    # We should end up with a PPONetworks object if everything is correct
+    network_wrapper = BraxPPONetworksWrapper(
+        policy_network=MLP(layer_sizes=(512, 4)),
+        value_network=MLP(layer_sizes=(512, 1)),
+        action_distribution=distribution.NormalTanhDistribution,
+    )
+    ppo_networks = network_wrapper.make_ppo_networks(
+        observation_size=observation_size,
+        action_size=action_size,
+    )
+    assert isinstance(ppo_networks, PPONetworks)

--- a/tests/test_ppo_networks.py
+++ b/tests/test_ppo_networks.py
@@ -6,7 +6,8 @@ import pytest
 from brax.training import distribution
 from brax.training.agents.ppo.networks import PPONetworks
 
-from ambersim.rl.networks import MLP, BraxPPONetworksWrapper
+from ambersim.learning.architectures import MLP
+from ambersim.rl.helpers import BraxPPONetworksWrapper
 from ambersim.utils._internal_utils import _rmtree
 
 


### PR DESCRIPTION
Resolves #29.

- Implements a simple pickle-able MLP
- Adds a wrapper class for brax's `PPONetworks`
    - Makes it more obvious how to define custom architectures
    - Makes it easier to save and load the networks along with their parameters
- Adds an example of saving and loading policies for the pendulum

Edit from @alberthli: also resolves #28.