### PR TITLE
Fix `mujoco.viewer` import order bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,7 @@
 channels:
   - nvidia/label/cuda-11.8.0
+  - conda-forge
 dependencies:
   - cuda
   - python=3.11
+  - gxx_linux-64

--- a/examples/rl/pendulum/ex_swingup.py
+++ b/examples/rl/pendulum/ex_swingup.py
@@ -2,14 +2,9 @@ import functools
 import time
 from datetime import datetime
 
-# Note: mujoco viewer must load before jax
-# isort: off
+import jax
 import mujoco
 import mujoco.viewer
-
-# isort: on
-
-import jax
 from brax import envs
 from brax.training.agents.ppo import networks as ppo_networks
 from brax.training.agents.ppo import train as ppo


### PR DESCRIPTION
I was having an issue with `mujoco.viewer` and `jax` in a source install, where everything was fine with the following import order:

```
import mujoco
import mujoco.viewer
import jax
```

But a different order,
```
import jax
import mujoco
import mujoco.viewer
```
threw a mysterious `GLIBCXX_3.4.30 not found` error. 

It turns out the problem has to do with `miniconda3` using some old c++ libraries by default. This PR fixes the problem by including `gxx_linux-64` as an explicit conda dependency. It then reverts the import order hacks I used to get around the issue before.